### PR TITLE
Custom nimanfile path

### DIFF
--- a/lib/niman/cli/application.rb
+++ b/lib/niman/cli/application.rb
@@ -17,10 +17,10 @@ module Niman
         @silent = false
       end
 
-      desc "apply", "Applies a Nimanfile"
-      def apply
+      desc "apply [NIMANFILE]", "Applies a Nimanfile"
+      def apply(file='Nimanfile')
         begin
-          Niman::Recipe.from_file
+          Niman::Recipe.from_file(file)
           config = Niman::Recipe.configuration
           installer = Niman::Installer.new(shell: client_shell, managers:{
             debian: 'apt-get -y',

--- a/lib/niman/cli/application.rb
+++ b/lib/niman/cli/application.rb
@@ -39,16 +39,16 @@ module Niman
         end
       end
 
-      desc "setup", "Generates an empty Nimanfile"
-      def setup
+      desc "setup [FILENAME]", "Generates an empty Nimanfile"
+      def setup(filename=Niman::Recipe::DEFAULT_FILENAME)
         content = <<-EOS
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 Niman::Recipe.configure do |config|
 end
         EOS
-        File.open(Niman::Recipe::DEFAULT_FILENAME, "w") { |handle| handle.write(content) }
-        say "Created new file #{Niman::Recipe::DEFAULT_FILENAME}"
+        File.open(filename, "w") { |handle| handle.write(content) }
+        say "Created new file #{filename}"
       end
     end
   end

--- a/lib/niman/recipe.rb
+++ b/lib/niman/recipe.rb
@@ -16,13 +16,12 @@ module Niman
       @configuration
     end
 
-    def self.reset!
+    def self.reset
       @configuration = Niman::Nimanfile.new
     end
 
-    def self.from_file
-      path = File.join(Dir.pwd, DEFAULT_FILENAME)
-      load DEFAULT_FILENAME
+    def self.from_file(filename)
+      load filename
     end
   end
 end

--- a/spec/lib/recipe_spec.rb
+++ b/spec/lib/recipe_spec.rb
@@ -25,7 +25,7 @@ describe Niman::Recipe do
           file.content = 'hello from alice'
         end
       end
-      Niman::Recipe.reset!
+      Niman::Recipe.reset
     end
 
     it 'erases current configuration' do
@@ -45,14 +45,21 @@ describe Niman::Recipe do
       end
       EOS
       File.open(Niman::Recipe::DEFAULT_FILENAME, "w") {|handle| handle.write(content) }
+      File.open('CustomNimanfile', "w") {|handle| handle.write(content) }
     end
     after do
       File.delete(Niman::Recipe::DEFAULT_FILENAME)
       FakeFS.activate!
+      Niman::Recipe.reset
     end
 
-    it 'loads "Nimanfile" by default' do
-      Niman::Recipe.from_file
+    it 'loads "Nimanfile"' do
+      Niman::Recipe.from_file(Niman::Recipe::DEFAULT_FILENAME)
+      expect(Niman::Recipe.configuration.instructions.length).to eq 1
+    end
+
+    it 'loads Nimanfile from custom path' do
+      Niman::Recipe.from_file('CustomNimanfile')
       expect(Niman::Recipe.configuration.instructions.length).to eq 1
     end
   end


### PR DESCRIPTION
This PR enhances Niman with the functionality to also accept a custom path for `Nimanfile`:

```bash
$ niman apply ~/files/MyNimanfile
```