### PR TITLE
New API for config.file

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,8 @@ It starts with a `Nimanfile`:
 
 ```ruby
 Niman::Recipe.configure do |config|
-  config.file do |file|
-    file.path = '/home/bob/hello.txt'
+  config.file '/home/bob/hello.txt' do |file|
     file.content = 'hello from alice'
-    file.mode = '0600'
   end
 end
 ```

--- a/lib/niman/nimanfile.rb
+++ b/lib/niman/nimanfile.rb
@@ -8,8 +8,8 @@ module Niman
       @instructions = []
     end
 
-    def file
-      f = Niman::Library::File.new
+    def file(path)
+      f = Niman::Library::File.new(path: path)
       yield(f)
       @instructions.push(f)
     end

--- a/spec/lib/nimanfile_spec.rb
+++ b/spec/lib/nimanfile_spec.rb
@@ -15,8 +15,15 @@ describe Niman::Nimanfile do
     end
   end
 
-  specify 'file calls block with config object' do
-    expect { |b| niman_file.file(&b) }.to yield_with_args(Niman::Library::File)
+  describe '#file' do
+    it 'calls block with config object' do
+      expect { |b| niman_file.file('/home/foo.txt', &b) }.to yield_with_args(Niman::Library::File)
+    end
+
+    it 'sets path' do
+      niman_file.file('/home/foo.txt') {}
+      expect(niman_file.instructions.first.path).to eq '/home/foo.txt'
+    end
   end
 
   specify 'package calls block with config object' do
@@ -25,7 +32,7 @@ describe Niman::Nimanfile do
 
   describe '#instructions' do
     before do
-      niman_file.file {}
+      niman_file.file('') {}
     end
 
     specify 'increases when #file is being called' do

--- a/spec/lib/recipe_spec.rb
+++ b/spec/lib/recipe_spec.rb
@@ -5,8 +5,7 @@ describe Niman::Recipe do
   describe '.configure' do
     before do
       Niman::Recipe.configure do |config|
-        config.file do |file|
-          file.path = '/home/bob/hello.txt'
+        config.file '/home/bob/hello.txt' do |file|
           file.content = 'hello from alice'
         end
       end
@@ -20,8 +19,7 @@ describe Niman::Recipe do
   describe '.reset' do
     before do
       Niman::Recipe.configure do |config|
-        config.file do |file|
-          file.path = '/home/bob/hello.txt'
+        config.file '/home/bob/hello.txt' do |file|
           file.content = 'hello from alice'
         end
       end
@@ -38,8 +36,7 @@ describe Niman::Recipe do
       FakeFS.deactivate!
       content = <<-EOS
       Niman::Recipe.configure do |config|
-        config.file do |file|
-          file.path = '/home/bob/hello.txt'
+        config.file '/home/bob/hello.txt' do |file|
           file.content = 'hello from alice'
         end
       end


### PR DESCRIPTION
pass filename directly to `#file` instead of setting it inside of the block